### PR TITLE
Fix: LRC thread SSL/network crasbes

### DIFF
--- a/lyrics/lrclib.py
+++ b/lyrics/lrclib.py
@@ -1,3 +1,4 @@
+import time
 from lrclib import LrcLibAPI
 from .parsing import lrc_to_dictionary
 
@@ -5,6 +6,17 @@ from .parsing import lrc_to_dictionary
 class LRCLibLyrics:
     def __init__(self):
         self.lyrics_api = LrcLibAPI(user_agent="VRC-Lyrics")
+        self.max_retries = 2
+        self.retry_delay_s = 0.5
+
+    def _search_lyrics(self, title, artist):
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                return self.lyrics_api.search_lyrics(track_name=title, artist_name=artist)
+            except:
+                if attempt == self.max_retries:
+                    return None
+                time.sleep(self.retry_delay_s * attempt)
 
     def get_lyrics(self, playback):
         duration = playback.duration_ms / 1000
@@ -13,7 +25,9 @@ class LRCLibLyrics:
         for wc in range(len(words), 0, -1):
             title = ' '.join(words[:wc])
             for artist in playback.artists:
-                results = self.lyrics_api.search_lyrics(track_name=title, artist_name=artist['name'])
+                results = self._search_lyrics(title, artist['name'])
+                if results is None:
+                    return None
                 filtered = [r for r in results if r.synced_lyrics and abs(r.duration - duration) <= 3]
                 if filtered:
                     return lrc_to_dictionary(filtered[0].synced_lyrics)


### PR DESCRIPTION
Added handling around search_lyrics calls preventing crashes.

SSL/network errors don’t crash the LRC thread. It now retries briefly and then returns None instead of bubbling a fatal exception.

+ Added retry/backoff and exception handling in lrclib.py.