### PR TITLE
Fix OSC thread dying silently on transient send failures

### DIFF
--- a/core/osc_manager.py
+++ b/core/osc_manager.py
@@ -1,4 +1,5 @@
 import queue
+import logging
 import config
 from pythonosc.udp_client import SimpleUDPClient
 from .messages import LyricUpdate, SongUpdate, IsPlayingUpdate
@@ -59,15 +60,28 @@ class BaseOSCManager:
             try:
                 msg = self.song_data_queue.get(timeout=10)
             except queue.Empty:
-                self.send_osc_message()
+                self._safe(self.send_osc_message)
             else:
                 if msg is None:
                     break
 
                 self.song_data_queue.put(msg)
-                self.process_queue_messages()
+                self._safe(self.process_queue_messages)
 
-        self.client.send_message(self.osc_path, ["", True, False])
+        self._safe(lambda: self.client.send_message(self.osc_path, ["", True, False]))
+
+    def _safe(self, fn):
+        """Runs fn, logging and swallowing OSError instead of letting it kill this thread.
+
+        OSC sends can fail transiently (e.g. VRChat not listening yet during a
+        world load, or a dropped connection) - without this, an unhandled
+        OSError here silently kills the OSC thread for the rest of the
+        session, since nothing else supervises or restarts it.
+        """
+        try:
+            fn()
+        except OSError as e:
+            logging.warning("OSC send failed, will retry: %s", e)
 
 
 class ChatboxManager(BaseOSCManager):


### PR DESCRIPTION
## Problem

`core/osc_manager.py`'s `BaseOSCManager.run()` (the thread that actually sends chatbox/OSC updates to VRChat) has no exception handling around `client.send_message()`. It's started in `service_manager.py` as a bare `threading.Thread(target=lambda: self._create_osc_manager(ip, port).run(), daemon=True)` - unlike the Spotify polling thread, which *is* wrapped in a try/except (`_run_lrc`).

If a single OSC send raises (e.g. the well-documented `OSError: [WinError 10054] An existing connection was forcibly closed by the remote host`, which happens on Windows when VRChat briefly isn't listening on the OSC port during a world load/restart/OSC toggle), that exception propagates all the way out of the thread target with nothing supervising it. Since the built app runs windowed/no-console, the default "Exception in thread ..." traceback has nowhere to go.

Net effect: the thread dies silently and permanently. The app keeps running, Spotify polling keeps working fine, but the in-game chatbox freezes on whatever was last successfully sent - forever, until the app is restarted. No error, no crash, no indication anything is wrong. This matches user reports of the app "freezing on the last song" and "silently not working" after playing for a while.

## Fix

Wrap the per-iteration OSC sends in a small `_safe()` helper that catches `OSError`, logs a warning, and lets the `run()` loop continue - so a transient send failure is retried on the next cycle instead of permanently killing the thread. Minimal, scoped diff, no behavior change on the happy path.

## Reproduction

I put together a standalone harness that imports the real, unmodified `core/osc_manager.py` + `core/messages.py` and drives them exactly the way `service_manager.py` does in production (same unguarded-thread wiring), against a fake UDP "VRChat" listener:

1. VRChat sim listens normally, chatbox updates arrive fine.
2. VRChat sim stops listening (simulating a world load), and the next OSC send is made to raise the same `OSError` Windows raises in this scenario (this one step is fault-injected, since the OS-level network race that produces it isn't reliably reproducible cross-platform/on demand - everything else is the real code, unmodified).
3. Confirmed **before this fix**: the OSC thread dies (`is_alive() == False`), zero further chatbox updates are ever sent, and it never recovers even after the VRChat sim starts listening again.
4. Confirmed **after this fix**: a warning is logged, the thread survives, and once the VRChat sim is listening again all queued updates go through normally.
